### PR TITLE
Fix evaluation environments when `arguments` is used

### DIFF
--- a/R/doubletruncation.R
+++ b/R/doubletruncation.R
@@ -43,7 +43,8 @@ nll_ditrunc_elife <-
     if(!is.null(arguments)){
       call <- match.call(expand.dots = FALSE)
       arguments <- check_arguments(func = nll_ditrunc_elife, call = call, arguments = arguments)
-      return(do.call(nll_ditrunc_elife, args = arguments))
+      caller_env <- parent.frame()
+      return(do.call(nll_ditrunc_elife, args = arguments, envir = caller_env))
     }
 
   family <- match.arg(family)
@@ -252,7 +253,8 @@ fit_ditrunc_elife <- function(
   if(!is.null(arguments)){
     call <- match.call(expand.dots = FALSE)
     arguments <- check_arguments(func = fit_ditrunc_elife, call = call, arguments = arguments)
-    return(do.call(fit_ditrunc_elife, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(fit_ditrunc_elife, args = arguments, envir = caller_env))
   }
   stopifnot("Argument `restart` should be a logical vector" = is.logical(restart) & length(restart) == 1L)
   if(is.null(weights)){
@@ -553,7 +555,8 @@ test_ditrunc_elife <- function(time,
   if(!is.null(arguments)){
     call <- match.call(expand.dots = FALSE)
     arguments <- check_arguments(func = test_ditrunc_elife, call = call, arguments = arguments)
-    return(do.call(test_ditrunc_elife, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(test_ditrunc_elife, args = arguments, envir = caller_env))
   }
   family <- match.arg(family)
   stopifnot("Covariate must be provided" = !missing(covariate),

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -41,7 +41,8 @@ endpoint.profile <- function(
       call = call,
       arguments = arguments
     )
-    return(do.call(endpoint.profile, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(endpoint.profile, args = arguments, envir = caller_env))
   }
   stopifnot(
     "Argument \"psi\" must be provided (currently NULL)" = !is.null(psi),
@@ -170,7 +171,8 @@ endpoint.tstab <- function(
       call = call,
       arguments = arguments
     )
-    return(do.call(endpoint.tstab, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(endpoint.tstab, args = arguments, envir = caller_env))
   }
   if (length(thresh) <= 1) {
     stop("Vector \"thresh\" must contain multiple thresholds.")

--- a/R/hazard.R
+++ b/R/hazard.R
@@ -74,7 +74,8 @@ hazard_elife <- function(x,
   if(!is.null(arguments)){
     call <- match.call(expand.dots = FALSE)
     arguments <- check_arguments(func = hazard_elife, call = call, arguments = arguments)
-    return(do.call(hazard_elife, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(hazard_elife, args = arguments, envir = caller_env))
   }
   stopifnot("The level of the confidence interval must be in [0,1]" = level > 0 && level < 1,
             "Level should be a numeric of length one" = length(level) == 1L,

--- a/R/misc.R
+++ b/R/misc.R
@@ -201,13 +201,11 @@ check_arguments <- function(func, call, arguments = NULL) {
   new.arguments <- arguments.default
   # Override any default argument with the values in arguments
   new.arguments[names(arguments)] <- arguments
-  # Function from https://stackoverflow.com/a/51389399
-  to_list <- function(x) {
-    xex <- parse(text = x)[[1]]
-    xex[[1]] <- quote(list)
-    eval.parent(xex)
-  }
-  supplied.arguments <- to_list(deparse(call[names(call) != "arguments"]))
+  
+  # Get supplied arguments from the call without evaluating
+  supplied.arguments <- as.list(call[-1])
+  supplied.arguments[["arguments"]] <- NULL
+  
   new.arguments[names(supplied.arguments)] <- supplied.arguments
   stopifnot(
     "Mandatory \"time\" vector not supplied." = !is.null(new.arguments$time)

--- a/R/nonparametric.R
+++ b/R/nonparametric.R
@@ -124,7 +124,8 @@ np_elife <- function(time,
   if(!is.null(arguments)){
     call <- match.call(expand.dots = FALSE)
     arguments <- check_arguments(func = np_elife, call = call, arguments = arguments)
-    return(do.call(np_elife, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(np_elife, args = arguments, envir = caller_env))
   }
   type <- match.arg(type)
   method <- match.arg(method)
@@ -707,7 +708,8 @@ npsurv <- function(time,
   if(!is.null(arguments)){
     call <- match.call(expand.dots = FALSE)
     arguments <- check_arguments(func = npsurv, call = call, arguments = arguments)
-    return(do.call(npsurv, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(npsurv, args = arguments, envir = caller_env))
   }
   stopifnot("`time` must be a numeric vector." = is.numeric(time))
   args <- list(...)

--- a/R/northrop.R
+++ b/R/northrop.R
@@ -361,7 +361,8 @@ nc_test <- function(
       call = call,
       arguments = arguments
     )
-    return(do.call(nc_test, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(nc_test, args = arguments, envir = caller_env))
   }
 
   # Exclude doubly interval truncated data

--- a/R/parametric.R
+++ b/R/parametric.R
@@ -55,7 +55,8 @@ nll_elife <- function(par,
   if(!is.null(arguments)){
     call <- match.call(expand.dots = FALSE)
     arguments <- check_arguments(func = "nll_elife", call = call, arguments = arguments)
-    return(do.call(nll_elife, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(nll_elife, args = arguments, envir = caller_env))
   }
   if(is.null(time)){
     stop("argument \"time\" is missing, with no default")
@@ -338,7 +339,8 @@ fit_elife <- function(time,
   if(!is.null(arguments)){
     call <- match.call(expand.dots = FALSE)
     arguments <- check_arguments(func = fit_elife, call = call, arguments = arguments)
-    return(do.call(fit_elife, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(fit_elife, args = arguments, envir = caller_env))
   }
 
   stopifnot("Argument `restart` should be a logical vector" = is.logical(restart) & length(restart) == 1L)

--- a/R/posterior.R
+++ b/R/posterior.R
@@ -164,7 +164,8 @@ lpost_elife <- function(par,
   if(!is.null(arguments)){
     call <- match.call(expand.dots = FALSE)
     arguments <- check_arguments(func = lpost_elife, call = call, arguments = arguments)
-    return(do.call(lpost_elife, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(lpost_elife, args = arguments, envir = caller_env))
   }
   type <- match.arg(type)
   family <- match.arg(family)

--- a/R/tests.R
+++ b/R/tests.R
@@ -57,7 +57,8 @@ test_elife <- function(
       call = call,
       arguments = arguments
     )
-    return(do.call(test_elife, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(test_elife, args = arguments, envir = caller_env))
   }
 
   family <- match.arg(family)
@@ -409,7 +410,8 @@ ks_test <- function(
       call = call,
       arguments = arguments
     )
-    return(do.call(ks_test, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(ks_test, args = arguments, envir = caller_env))
   }
   # Exclude doubly interval truncated data
   if (

--- a/R/threshstab.R
+++ b/R/threshstab.R
@@ -60,7 +60,8 @@ tstab <- function(
       call = call,
       arguments = arguments
     )
-    return(do.call(tstab, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(tstab, args = arguments, envir = caller_env))
   }
   family <- match.arg(family)
   method <- match.arg(method)
@@ -386,7 +387,8 @@ prof_gp_shape <-
         call = call,
         arguments = arguments
       )
-      return(do.call(prof_gp_shape, args = arguments))
+      caller_env <- parent.frame()
+      return(do.call(prof_gp_shape, args = arguments, envir = caller_env))
     }
     if (is.null(weights)) {
       weights <- rep(1, length(time))
@@ -508,7 +510,8 @@ prof_gp_scalet <-
         call = call,
         arguments = arguments
       )
-      return(do.call(prof_gp_scalet, args = arguments))
+      caller_env <- parent.frame()
+      return(do.call(prof_gp_scalet, args = arguments, envir = caller_env))
     }
 
     if (is.null(weights)) {
@@ -639,7 +642,8 @@ prof_exp_scale <- function(
       call = call,
       arguments = arguments
     )
-    return(do.call(prof_exp_scale, args = arguments))
+    caller_env <- parent.frame()
+    return(do.call(prof_exp_scale, args = arguments, envir = caller_env))
   }
   type <- match.arg(type)
   stopifnot(


### PR DESCRIPTION
This PR implements the suggested fixes in #4 
     
> Suggested fixes:
> 
> 1. Remove evaluation from `check_arguments` because it doesn't seem to check the values of arguments (just existence). If checking the values is important, then the caller environment should be passed in to this function to evaluate the values from the correct environment.
> 
> 2. Specify the environment for `do.call()` to match the caller environment (rather than your function environment).